### PR TITLE
Request homepage newsfeed earlier

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -100,9 +100,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+    this.getNews();
     return this.expanseService
       .start()
-      .then(() => this.getNews())
       .then(() => this.getApps("rating", 1))
       .then(() => this.getApps("recent", 1))
       .then(() => this.getApps("rating", 0, null, "multiplayer"))


### PR DESCRIPTION
Currently, the newsfeed is not loaded until an API connection has been established. This moves the newsfeed request up to happen in parallel with the API request as it does not depend on it.