### PR TITLE
Update meta tags on app pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@angular/platform-browser": "~8.2.14",
     "@angular/platform-browser-dynamic": "~8.2.14",
     "@angular/router": "~8.2.14",
+    "@ngx-lite/json-ld": "^0.6.2",
     "@types/highlightjs": "^9.12.0",
     "@types/masonry-layout": "^4.2.1",
     "@types/uuid": "^3.4.5",

--- a/src/app/app-listing/app-listing.component.html
+++ b/src/app/app-listing/app-listing.component.html
@@ -32,6 +32,9 @@
   <div class="top-back" *ngIf="screenshots && screenshots.length">
 
   </div>
+
+  <ngx-json-ld [json]="linkedData"></ngx-json-ld>
+
   <h4 style="padding-left: 8px;">
     <!--    <i class="material-icons back-icon" (click)="backClicked()">reply</i>-->
     <!--    <img class="responsive-img top-image pointer"-->

--- a/src/app/app-listing/app-listing.component.spec.ts
+++ b/src/app/app-listing/app-listing.component.spec.ts
@@ -1,56 +1,45 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AppListingComponent } from "./app-listing.component";
-import { LazyLoadImageModule } from "ng-lazyload-image";
-import {
-  MzTooltipModule,
-  MzModalModule,
-  MzButtonModule,
-  MzToastModule
-} from "ngx-materialize";
-import { RouterTestingModule } from "@angular/router/testing";
-import { FromNowPipe } from "../from-now.pipe";
-import { EncodeUriPipe } from "../encode-uri.pipe";
-import { RecaptchaModule } from "ng-recaptcha";
-import { FormsModule } from "@angular/forms";
-import { LightboxModule } from "ngx-lightbox";
-import { AbbreviateNumberPipe } from "../abbreviate-number.pipe";
-import { FormatNumberPipe } from "../format-number.pipe";
+import { AppListingComponent } from './app-listing.component';
+import { LazyLoadImageModule } from 'ng-lazyload-image';
+import { MzTooltipModule, MzModalModule, MzButtonModule, MzToastModule } from 'ngx-materialize';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FromNowPipe } from '../from-now.pipe';
+import { EncodeUriPipe } from '../encode-uri.pipe';
+import { RecaptchaModule } from 'ng-recaptcha';
+import { FormsModule } from '@angular/forms';
+import { LightboxModule } from 'ngx-lightbox';
+import { AbbreviateNumberPipe } from '../abbreviate-number.pipe';
+import { FormatNumberPipe } from '../format-number.pipe';
 
-describe("AppListingComponent", () => {
-  let component: AppListingComponent;
-  let fixture: ComponentFixture<AppListingComponent>;
+describe('AppListingComponent', () => {
+    let component: AppListingComponent;
+    let fixture: ComponentFixture<AppListingComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        LazyLoadImageModule,
-        MzTooltipModule,
-        MzModalModule,
-        RecaptchaModule,
-        FormsModule,
-        MzButtonModule,
-        MzToastModule,
-        LightboxModule
-      ],
-      declarations: [
-        AppListingComponent,
-        FromNowPipe,
-        AbbreviateNumberPipe,
-        FormatNumberPipe,
-        EncodeUriPipe
-      ]
-    }).compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule,
+                LazyLoadImageModule,
+                MzTooltipModule,
+                MzModalModule,
+                RecaptchaModule,
+                FormsModule,
+                MzButtonModule,
+                MzToastModule,
+                LightboxModule,
+            ],
+            declarations: [AppListingComponent, FromNowPipe, AbbreviateNumberPipe, FormatNumberPipe, EncodeUriPipe],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AppListingComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AppListingComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/app-listing/app-listing.component.ts
+++ b/src/app/app-listing/app-listing.component.ts
@@ -733,7 +733,17 @@ export class AppListingComponent implements OnInit, OnDestroy {
 
         const dateCreated = new Date(+this.currentApp.created).toISOString().substring(0, 10);
         const dateModified = new Date(+this.currentApp.updated).toISOString().substring(0, 10);
-        const ratingValue = parseFloat((this.appRating as unknown) as string).toFixed(2);
+        const ratingCount = +this.appRatingTotal;
+        const ratingValue = ratingCount > 0 ? parseFloat((this.appRating as unknown) as string).toFixed(2) : undefined;
+        const aggregateRating =
+            ratingCount > 0
+                ? {
+                      '@type': 'AggregateRating',
+                      ratingValue,
+                      ratingCount,
+                      reviewCount: ratingCount,
+                  }
+                : undefined;
 
         this.linkedData = {
             '@context': 'http://schema.org/',
@@ -751,11 +761,7 @@ export class AppListingComponent implements OnInit, OnDestroy {
             image: image ? image : undefined,
             name: this.currentApp.name,
             url,
-            aggregateRating: {
-                '@type': 'AggregateRating',
-                ratingValue,
-                reviewCount: this.appRatingTotal,
-            },
+            aggregateRating,
         };
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,125 +1,142 @@
-import {
-  AfterViewInit,
-  Component,
-  OnDestroy,
-  OnInit,
-  ViewChild
-} from "@angular/core";
-import { AppService } from "./app.service";
-import { Subscription } from "rxjs";
-import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
-import { MzToastService } from "ngx-materialize";
-import { ExpanseClientService } from "./expanse-client.service";
-import { UploadService } from "./upload.service";
-import { AppsToUpdateService } from "./apps-to-update.service";
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AppService } from './app.service';
+import { Subscription } from 'rxjs';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { MzToastService } from 'ngx-materialize';
+import { ExpanseClientService } from './expanse-client.service';
+import { UploadService } from './upload.service';
+import { AppsToUpdateService } from './apps-to-update.service';
+import { Meta, Title } from '@angular/platform-browser';
 declare const M;
 @Component({
-  selector: "app-root",
-  templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.css"]
+    selector: 'app-root',
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.css'],
 })
 export class AppComponent implements AfterViewInit, OnDestroy, OnInit {
-  @ViewChild("scrollContainer", { static: false }) scrollContainer;
-  @ViewChild("confirmOpen", { static: false }) confirmOpen;
-  title = "SideQuestWebsite";
-  sub: Subscription;
-  message_sound: any;
-  friend_sound: any;
-  @ViewChild("sideNav", { static: false }) sideNav;
-  constructor(
-    public expanseService: ExpanseClientService,
-    public appService: AppService,
-    private router: Router,
-    route: ActivatedRoute,
-    private toastService: MzToastService,
-    private uploadService: UploadService,
-    private appsToUpdateService: AppsToUpdateService
-  ) {
-    this.sub = router.events.subscribe(val => {
-      if (val instanceof NavigationEnd) {
-      }
-    });
-    this.expanseService.start();
-    // .then(() => this.expanseService.getInstalledApps("", 0));
-    this.setupAppUninstall();
-    this.expanseService.onusermessage = this.userMessage.bind(this);
+    @ViewChild('scrollContainer', { static: false }) scrollContainer;
+    @ViewChild('confirmOpen', { static: false }) confirmOpen;
+    title = 'SideQuestWebsite';
+    sub: Subscription;
+    message_sound: any;
+    friend_sound: any;
+    @ViewChild('sideNav', { static: false }) sideNav;
+    constructor(
+        public expanseService: ExpanseClientService,
+        public appService: AppService,
+        private router: Router,
+        route: ActivatedRoute,
+        private toastService: MzToastService,
+        private uploadService: UploadService,
+        private appsToUpdateService: AppsToUpdateService,
+        private meta: Meta,
+        private titleService: Title
+    ) {
+        this.sub = router.events.subscribe(val => {
+            if (val instanceof NavigationEnd) {
+                const isAppPage = val.urlAfterRedirects.startsWith('/app/');
+                if (!isAppPage) {
+                    this.setupHeadTags();
+                }
+            }
+        });
+        this.expanseService.start();
+        // .then(() => this.expanseService.getInstalledApps("", 0));
+        this.setupAppUninstall();
+        this.expanseService.onusermessage = this.userMessage.bind(this);
 
-    this.expanseService.onremoteinstall = this.appService.remoteInstall.bind(
-      this.appService
-    );
+        this.expanseService.onremoteinstall = this.appService.remoteInstall.bind(this.appService);
 
-    this.message_sound = new Audio();
-    this.message_sound.src = "../../assets/sounds/message.mp3";
-    this.friend_sound = new Audio();
-    this.friend_sound.src = "../../assets/sounds/message.mp3";
+        this.message_sound = new Audio();
+        this.message_sound.src = '../../assets/sounds/message.mp3';
+        this.friend_sound = new Audio();
+        this.friend_sound.src = '../../assets/sounds/message.mp3';
 
-    window.addEventListener("dragover", function(e: any) {
-      e.preventDefault();
-    });
-    window.addEventListener("drop", function(e: any) {
-      e.preventDefault();
-    });
-  }
-
-  ngOnDestroy() {
-    this.sub.unsubscribe();
-  }
-
-  userMessage(data) {
-    if (data.message.is_blocked) {
-    } else if (data.message.is_friend_request) {
-      this.appService.getNotifications(this.expanseService);
-      this.friend_sound.play();
-    } else if (data.message.spaces_id) {
-    } else {
-      this.appService.getNotifications(this.expanseService);
-      this.message_sound.play();
-      if (
-        this.appService.accountComponent &&
-        this.appService.accountComponent.mainPage === "message-thread"
-      ) {
-        this.appService.accountComponent.page = 0;
-        this.appService.accountComponent.getCurrent();
-      }
+        window.addEventListener('dragover', function(e: any) {
+            e.preventDefault();
+        });
+        window.addEventListener('drop', function(e: any) {
+            e.preventDefault();
+        });
     }
-  }
 
-  setupAppUninstall() {
-    (window as any).sideQuestRemove = pkg => {
-      let isChanged = false;
-      Object.keys(this.appService.app_index).forEach(apps_id => {
-        if (this.appService.app_index[apps_id] === pkg) {
-          this.expanseService.uninstallApp(apps_id);
-          isChanged = true;
+    ngOnDestroy() {
+        this.sub.unsubscribe();
+    }
+
+    userMessage(data) {
+        if (data.message.is_blocked) {
+        } else if (data.message.is_friend_request) {
+            this.appService.getNotifications(this.expanseService);
+            this.friend_sound.play();
+        } else if (data.message.spaces_id) {
+        } else {
+            this.appService.getNotifications(this.expanseService);
+            this.message_sound.play();
+            if (this.appService.accountComponent && this.appService.accountComponent.mainPage === 'message-thread') {
+                this.appService.accountComponent.page = 0;
+                this.appService.accountComponent.getCurrent();
+            }
         }
-      });
-      if (isChanged) {
-        this.appService.saveAppMeta();
-      }
-    };
-  }
+    }
 
-  scrollFire() {
-    return (
-      document.body.scrollTop > 180 ||
-      (window.innerWidth < 992 && document.body.scrollTop > 80)
-    );
-  }
+    setupAppUninstall() {
+        (window as any).sideQuestRemove = pkg => {
+            let isChanged = false;
+            Object.keys(this.appService.app_index).forEach(apps_id => {
+                if (this.appService.app_index[apps_id] === pkg) {
+                    this.expanseService.uninstallApp(apps_id);
+                    isChanged = true;
+                }
+            });
+            if (isChanged) {
+                this.appService.saveAppMeta();
+            }
+        };
+    }
 
-  ngOnInit() {
-    this.appService.getNotifications(this.expanseService);
-  }
+    scrollFire() {
+        return document.body.scrollTop > 180 || (window.innerWidth < 992 && document.body.scrollTop > 80);
+    }
 
-  ngAfterViewInit() {
-    this.appService.scrollContainer = this.scrollContainer.nativeElement;
-    this.appService.confirmOpen = this.confirmOpen;
-    this.appService.scrollContainer.addEventListener("scroll", () =>
-      window.dispatchEvent(new Event("scroll"))
-    );
-    this.appsToUpdateService.init();
-  }
+    ngOnInit() {
+        this.appService.getNotifications(this.expanseService);
+    }
 
-  openLink(url: string) {
-    window.location.href = url;
-  }
+    ngAfterViewInit() {
+        this.appService.scrollContainer = this.scrollContainer.nativeElement;
+        this.appService.confirmOpen = this.confirmOpen;
+        this.appService.scrollContainer.addEventListener('scroll', () => window.dispatchEvent(new Event('scroll')));
+        this.appsToUpdateService.init();
+    }
+
+    openLink(url: string) {
+        window.location.href = url;
+    }
+
+    private setupHeadTags() {
+        const title = 'SideQuest - Make it your own';
+        const description = 'SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets.';
+        const author = 'SideQuest';
+        const image = 'https://i.imgur.com/AlYMbTj.png';
+        const url = 'https://sidequestvr.com/';
+        const video = '';
+
+        this.titleService.setTitle(title);
+        this.meta.updateTag({ name: 'title', content: title });
+        this.meta.updateTag({ name: 'description', content: description });
+
+        this.meta.updateTag({ property: 'og:title', content: title });
+        this.meta.updateTag({ property: 'og:image', content: image });
+        this.meta.updateTag({ property: 'og:url', content: url });
+        this.meta.updateTag({ property: 'og:description', content: description });
+        this.meta.updateTag({ property: 'og:site_name', content: 'SideQuest' });
+        this.meta.updateTag({ property: 'og:video', content: video });
+
+        this.meta.updateTag({ property: 'twitter:title', content: title });
+        this.meta.updateTag({ property: 'twitter:site', content: '@SideQuestVR' });
+        this.meta.updateTag({ property: 'twitter:creator', content: author });
+        this.meta.updateTag({ property: 'twitter:description', content: description });
+        this.meta.updateTag({ property: 'twitter:image', content: image });
+    }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -99,6 +99,7 @@ import { BannerCarouselComponent } from './banner-carousel/banner-carousel.compo
 import { AbbreviateNumberPipe } from './abbreviate-number.pipe';
 import { FormatNumberPipe } from './format-number.pipe';
 import { ScriptingNetworkingComponent } from './scripting-networking/scripting-networking.component';
+import { NgxJsonLdModule } from '@ngx-lite/json-ld';
 
 export function hljsLanguages() {
     return [{ name: 'cs', func: cs }];
@@ -204,6 +205,7 @@ export function hljsLanguages() {
         LightboxModule,
         RecaptchaModule,
         AutocompleteLibModule,
+        NgxJsonLdModule,
     ],
     providers: [NotLoginGuard, LoginGuard, AppsToUpdateService],
     bootstrap: [AppComponent],

--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,16 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-152732171-1"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
     gtag('js', new Date());
+
   </script>
   <meta charset="utf-8">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -14,20 +19,26 @@
   <!-- Primary Meta Tags -->
   <title>SideQuest - Make it your own</title>
   <meta name="title" content="SideQuest">
-  <meta name="description" content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets. ">
+  <meta name="description"
+    content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets.">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://sidequestvr.com/">
   <meta property="og:title" content="SideQuest">
-  <meta property="og:description" content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets. ">
+  <meta property="og:description"
+    content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets.">
   <meta property="og:image" content="https://i.imgur.com/AlYMbTj.png">
+  <meta property="og:site_name" content="SideQuest">
+  <meta property="og:video" content="">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://sidequestvr.com/">
   <meta property="twitter:title" content="SideQuest">
-  <meta property="twitter:description" content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets. ">
+  <meta property="twitter:site" content="@SideQuestVR">
+  <meta property="twitter:creator" content="SideQuest">
+  <meta property="twitter:description"
+    content="SideQuest is a tool to help simplify getting content onto Quest and Go and other VR headsets.">
   <meta property="twitter:image" content="https://i.imgur.com/AlYMbTj.png">
   <base href="/">
 
@@ -40,7 +51,7 @@
   <link rel="apple-touch-icon" sizes="144x144" href="assets/icons/apple-icon-144x144.png">
   <link rel="apple-touch-icon" sizes="152x152" href="assets/icons/apple-icon-152x152.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-icon-180x180.png">
-  <link rel="icon" type="image/png" sizes="192x192"  href="assets/icons/android-icon-192x192.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/icons/android-icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="assets/icons/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16x16.png">
@@ -54,44 +65,52 @@
   <link href="https://fonts.googleapis.com/css?family=PT+Sans|Roboto" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 </head>
+
 <body>
   <app-root class="full-size">
     <style>
-      html,body{
+      html,
+      body {
         width: 100%;
         height: 100%;
         padding: 0;
         margin: 0;
         background: #0c0c0c;
-        color:white;
-        overflow:hidden;
-        position:relative;
+        color: white;
+        overflow: hidden;
+        position: relative;
         top: 0;
       }
+
       .initial-loader {
-        position:absolute;
+        position: absolute;
         top: 50%;
         left: 50%;
-        transform: translate(-50%,-50%);
+        transform: translate(-50%, -50%);
         text-align: center;
       }
-      .spinner{
+
+      .spinner {
         width: 60px;
         height: 60px;
         animation: spin 2s linear infinite;
-        border: 5px solid #f3f3f3; /* Light grey */
-        border-top: 5px solid #ed4e7a; /* Pink */
+        border: 5px solid #f3f3f3;
+        /* Light grey */
+        border-top: 5px solid #ed4e7a;
+        /* Pink */
         border-radius: 50%;
         position: relative;
         margin: auto;
 
       }
+
     </style>
     <div class="initial-loader">
-      <img style="width: 200px;" src="assets/images/new-logo.png"/>
+      <img style="width: 200px;" src="assets/images/new-logo.png" />
       <div class="spinner"></div>
     </div>
   </app-root>
 
 </body>
+
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,6 +959,13 @@
     tree-kill "1.2.2"
     webpack-sources "1.4.3"
 
+"@ngx-lite/json-ld@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@ngx-lite/json-ld/-/json-ld-0.6.2.tgz#9d319a4cfe253c2543a19aefea059d00b12e9d37"
+  integrity sha512-oFWyYqBPOKQZBqP2ev3Xkn5UjjiWAC1dKYsCduvpDJTA3phc573NhPDpBqxMDfoeIuu72QOJogPehFWJV5991w==
+  dependencies:
+    tslib "^1.9.0"
+
 "@schematics/angular@8.3.25":
   version "8.3.25"
   resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-8.3.25.tgz#11252399e30e2ddb94323e5e438bb69839fb9464"
@@ -1481,7 +1488,7 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
@@ -1490,14 +1497,6 @@ archy@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/archy/-/archy-0.0.2.tgz#910f43bf66141fc335564597abc189df44b3d35e"
   integrity sha1-kQ9Dv2YUH8M1VkWXq8GJ30Sz014=
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2710,11 +2709,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -3049,11 +3043,6 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
 deep-extend@~0.2.5:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.2.11.tgz#7a16ba69729132340506170494bc83f7076fe08f"
@@ -3139,11 +3128,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3179,11 +3163,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -4074,20 +4053,6 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
@@ -4343,11 +4308,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -4585,7 +4545,7 @@ husky@^3.0.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4699,7 +4659,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.5, ini@^1.2.0, ini@^1.3.4, ini@~1.3.0:
+ini@1.3.5, ini@^1.2.0, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6209,15 +6169,6 @@ natives@^1.1.3:
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -6369,22 +6320,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.47, node-releases@^1.1.50:
   version "1.1.50"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.50.tgz#803c40d2c45db172d0410e4efec83aa8c6ad0592"
@@ -6396,14 +6331,6 @@ node-uuid@~1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
   integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 nopt@~1.0.10:
   version "1.0.10"
@@ -6502,7 +6429,7 @@ npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6:
+npm-packlist@^1.1.12:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -6564,16 +6491,6 @@ npmconf@^2.0.1:
     safe-buffer "^5.1.1"
     semver "2 || 3 || 4"
     uid-number "0.0.5"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 null-check@^1.0.0:
   version "1.0.0"
@@ -6824,7 +6741,7 @@ osenv@0.1.0:
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.0.tgz#61668121eec584955030b9f470b1d2309504bfcb"
   integrity sha1-YWaBIe7FhJVQMLn0cLHSMJUEv8s=
 
-osenv@^0.1.0, osenv@^0.1.4, osenv@^0.1.5:
+osenv@^0.1.0, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -7542,16 +7459,6 @@ raw-loader@3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -7614,7 +7521,7 @@ read@~1.0.4:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -7961,7 +7868,7 @@ rfdc@^1.1.4:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
   integrity sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8078,7 +7985,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8220,7 +8127,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -8715,7 +8622,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -8852,11 +8759,6 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
@@ -8939,7 +8841,7 @@ tar-stream@^0.4.6:
     readable-stream "^1.0.27-1"
     xtend "^4.0.0"
 
-tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -9678,13 +9580,6 @@ which@~1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
   integrity sha1-RgwdoPgQED0DIam2M6+eV15kSG8=
-
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
 
 win-release@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
When browsing to an app page, title, description, as well as Open Graph and Twiter meta tags are updated. A JSON-LD schema is also included on app pages. All other pages show default meta tags.

Example of meta tags for [Pavlov: Shack](https://sidequestvr.com/#/app/392):

![chrome_2020-03-26_00-47-43](https://user-images.githubusercontent.com/286531/77622441-824aac80-6efb-11ea-9a7f-a88592e36656.png)

Example of JSON-LD for [Pavlov: Shack](https://sidequestvr.com/#/app/392):

![chrome_2020-03-26_00-47-11](https://user-images.githubusercontent.com/286531/77622456-8a0a5100-6efb-11ea-90ff-c35fc4cd3cf9.png)

Example of meta tags for any non-app page:

![chrome_2020-03-26_00-50-21](https://user-images.githubusercontent.com/286531/77622638-dc4b7200-6efb-11ea-9c93-8c9756cc24c0.png)
